### PR TITLE
Provide more complete installation instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,10 +31,23 @@ The work on C++ side of auto-generation is mostly completed. Checks for some spe
  - Generate final namespace C++ code
  - Handle types.hpp
 
+## Trying the bindings
 
-To run, clone this repository into a folder named julia inside the OpenCV's source modules folder. Then modify hdr_parser.py with appropriate header file names and use
+To build:
 
-```python3 gen3_{lang}.py```
+- from within Julia, add the `CxxWrap` package (https://github.com/JuliaInterop/CxxWrap.jl) with `pkg> add CxxWrap` followed by `using CxxWrap`. Obtain the "prefix path" from `julia> CxxWrap.prefix_path()`; note this for future use.
+- clone OpenCV itself from https://github.com/opencv/opencv
+- enter the `modules` directory and clone this repository to a folder named `julia`, e.g., `git clone git@github.com:archit120/JuliaOpenCVBindingGenerator.git julia`
+- enter the `julia/src2` directory and edit `hdr_parser.py`. Replace the hard-coded paths in the `modpath` and `opencv_hdr_list` to those appropriate for your system
+- from the command line, execute `python3 gen3_julia.py`. The script will output files in autogen_* folders. 
+- return to the top-level OpenCV source directory. Launch `cmake-gui`, set up the source path, configure the build path. (Some instructions can be found at https://towardsdatascience.com/how-to-install-opencv-and-extra-modules-from-source-using-cmake-and-then-set-it-up-in-your-pycharm-7e6ae25dbac5.) After clicking "Configure", edit the configuration to implement the following modifications:
+  + Add `julia` to the `OPENCV_EXTRA_MODULES_PATH` (you can browse to set the path)
+  + You will likely need to create a variable called `CMAKE_PREFIX_PATH` (using `Add Entry` in the GUI) and set its value to a `PATH` taken from the `CxxWrap.prefix_path()` command above
+  + I had to create a `FindOpenCV.cmake` file by copy/pasting https://cmake-basis.github.io/apidoc/latest/FindOpenCV_8cmake_source.html. I added this to the opencv source directory and then clicked "Add Entry" and created `CMAKE_MODULE_PATH` and set it to point to the directory with `FindOpenCV.cmake`.
+  + I edited the `OpenCV_DIR` entry to point to the top-level OpenCV source directory
+- Click "Configure" again. Address any errors that you encounter.
+  
+  
 
-The script will output files in autogen_* folders. 
-
+To run a demonstration:
+- ??


### PR DESCRIPTION
I'm finally giving this a try, but struggling on the build. This PR shows what I've been trying, but I'm stuck on an error
```
Detected processor: x86_64
Looking for ccache - not found
Found ZLIB: /usr/lib/x86_64-linux-gnu/libz.so (found suitable version "1.2.11", minimum required is "1.2.3") 
Could NOT find JPEG (missing: JPEG_LIBRARY JPEG_INCLUDE_DIR) 
libjpeg-turbo: VERSION = 2.0.5, BUILD = opencv-4.4.0-dev-libjpeg-turbo
Could NOT find TIFF (missing: TIFF_LIBRARY TIFF_INCLUDE_DIR) 
Could NOT find OpenJPEG (minimal suitable version: 2.0, recommended version >= 2.3.1)
Could NOT find Jasper (missing: JASPER_LIBRARIES JASPER_INCLUDE_DIR) 
Found ZLIB: /usr/lib/x86_64-linux-gnu/libz.so (found version "1.2.11") 
Checking for module 'gtk+-3.0'
  No package 'gtk+-3.0' found
Checking for module 'gtk+-2.0'
  No package 'gtk+-2.0' found
Checking for module 'gthread-2.0'
  No package 'gthread-2.0' found
found Intel IPP (ICV version): 2020.0.0 [2020.0.0 Gold]
at: /home/tim/src/opencv/build/3rdparty/ippicv/ippicv_lnx/icv
found Intel IPP Integration Wrappers sources: 2020.0.0
at: /home/tim/src/opencv/build/3rdparty/ippicv/ippicv_lnx/iw
Could not find OpenBLAS include. Turning OpenBLAS_FOUND off
Could not find OpenBLAS lib. Turning OpenBLAS_FOUND off
Could NOT find Atlas (missing: Atlas_CBLAS_INCLUDE_DIR Atlas_CLAPACK_INCLUDE_DIR Atlas_CBLAS_LIBRARY Atlas_BLAS_LIBRARY Atlas_LAPACK_LIBRARY) 
A library with BLAS API not found. Please specify library location.
LAPACK requires BLAS
A library with LAPACK API not found. Please specify library location.
Could NOT find JNI (missing: JAVA_INCLUDE_PATH JAVA_INCLUDE_PATH2 JAVA_AWT_INCLUDE_PATH) 
VTK is not found. Please set -DVTK_DIR in CMake to VTK build directory, or to VTK install subdirectory with VTKConfig.cmake file
OpenCV Python: during development append to PYTHONPATH: /home/tim/src/opencv/build/python_loader
Checking for modules 'libavcodec;libavformat;libavutil;libswscale'
  No package 'libavcodec' found
  No package 'libavformat' found
  No package 'libavutil' found
  No package 'libswscale' found
Checking for module 'gstreamer-base-1.0'
  No package 'gstreamer-base-1.0' found
Checking for module 'gstreamer-app-1.0'
  No package 'gstreamer-app-1.0' found
Checking for module 'gstreamer-riff-1.0'
  No package 'gstreamer-riff-1.0' found
Checking for module 'gstreamer-pbutils-1.0'
  No package 'gstreamer-pbutils-1.0' found
Checking for module 'libdc1394-2'
  No package 'libdc1394-2' found
Found Julia executable: /home/tim/bin/julia
Julia_VERSION_STRING: 1.5.0
Julia_INCLUDE_DIRS:   /home/tim/src/julia-1/usr/include/julia
Julia_LIBRARY_DIR:    /home/tim/src/julia-1/usr/lib
Julia_LIBRARY:        /home/tim/src/julia-1/usr/lib/libjulia.so.1
JULIA_HOME:           /home/tim/src/julia-1/usr/bin
Julia_LLVM_VERSION:   v9.0.1
Julia_WORD_SIZE:      64
Found JlCxx at /home/tim/.julia/artifacts/fd5dfb5dee87c41c238d98bd7ff2fdd4f307e824/lib
CMake Error at FindOpenCV.cmake:291 (message):
  The following required OpenCV components were not found:
  cxcore;cv;ml;highgui;cvaux
Call Stack (most recent call first):
  modules/julia/src2/CMakeLists.txt:15 (FIND_PACKAGE)


Configuring incomplete, errors occurred!
See also "/home/tim/src/opencv/build/CMakeFiles/CMakeOutput.log".
See also "/home/tim/src/opencv/build/CMakeFiles/CMakeError.log".
```