### PR TITLE
WIP: Towards a more "Julian" package

### DIFF
--- a/src2/jl_cxx_files/Mat.jl
+++ b/src2/jl_cxx_files/Mat.jl
@@ -1,22 +1,43 @@
-#Adapted from IndirectArray
+struct Mat{T, N, A<:AbstractArray{T,N}} <: DenseArray{T, N}
+    mat::CxxMat
+    data::A
 
-struct Mat{T <: dtypes} <: AbstractArray{T,3}
-    mat
-    data_raw
-    data
-
-    @inline function Mat{T}(mat, data_raw::AbstractArray{T,3}) where {T <: dtypes}
-        data = reinterpret(T, data_raw)
-        new{T}(mat, data_raw, data)
+    function Mat{T, N, A}(mat, data_raw::A) where {T, N, A}
+        ok, msg = validate(data_raw)
+        ok || error(msg)
+        new{T, N, A}(mat, data_raw)
     end
 
-    @inline function Mat(data_raw::AbstractArray{T, 3}) where {T <: dtypes}
-        data = reinterpret(T, data_raw)
-        mat = nothing
-        new{T}(mat, data_raw, data)
+    function Mat{T, N, A}(data_raw::A) where {T, N, A}
+        ok, msg = validate(data_raw)
+        ok || error(msg)
+        new{T, N, A}(nothing, data_raw)
     end
 end
+Mat{T, N}(mat, data::StridedArray{T, N}) = Mat{T, N, typeof(data)}(mat, data)
+Mat{T, N}(data::StridedArray{T, N}) = Mat{T, N, typeof(data)}(data)
+Mat{T, N}(mat, data::AbstractArray{T, N}) = Mat{T, N}(mat, copy(data)::StridedArray)
+Mat{T, N}(data::AbstractArray{T, N}) = Mat{T, N}(copy(data)::StridedArray)
+Mat{T}(mat, data::AbstractArray{T}) = Mat{T, ndims(data)}(mat, data)
+Mat{T}(data::AbstractArray{T}) = Mat{T, ndims(data)}(data)
+Mat(data) = Mat{eltype(data)}(data)
+Mat(data::AbstractArray{Color{T, N}}) where {T, N} = Mat(reinterpret(SVector{N, T}, data))
+Mat(data::AbstractArray{ColorAlpha{C, T, N}}) where {C, T, N} = Mat(reinterpret(SVector{N, T}, data))
 
+function validate(data)
+    s = strides(data)
+    s[1] == 1 || return false, "first stride must be 1"
+    sz = size(data)
+    for i = 2:length(s)
+        s[i] == s[i-1] * sz[i-1] || return false, "array is not dense"
+    end
+    # eltype(eltype(data)) lets us support SVector{N, T<:dtype},
+    # and eltype(eltype(UInt8)) === UInt8 so it's safe even for dtypes
+    eltype(eltype(data)) <: dtypes || return false, "unsupported element type $(eltype(eltype(data)))"
+    return true, ""
+end
+
+# why is this needed?
 function Base.deepcopy_internal(x::Mat{T}, y::IdDict) where {T}
     if haskey(y, x)
         return y[x]
@@ -28,7 +49,7 @@ end
 
 Base.size(A::Mat) = size(A.data)
 Base.axes(A::Mat) = axes(A.data)
-Base.IndexStyle(::Type{Mat{T}}) where {T} = IndexCartesian()
+Base.IndexStyle(::Type{Mat{T, N, A}}) where {T, N, A} = IndexStyle(A)
 
 Base.strides(A::Mat{T}) where {T} = strides(A.data)
 Base.copy(A::Mat{T}) where {T} = Mat(copy(A.data_raw))
@@ -45,5 +66,4 @@ end
 @inline function Base.setindex!(A::Mat, x, I::Vararg{Int,3})
     @boundscheck checkbounds(A.data, I...)
     A.data[I...] = x
-    return A
 end

--- a/src2/jl_cxx_files/cv_cxx.jl
+++ b/src2/jl_cxx_files/cv_cxx.jl
@@ -1,8 +1,11 @@
-# using StaticArrays
+using StaticArrays
+using FixedPointNumbers
+using ColorTypes
 
 include("typestructs.jl")
 include("Vec.jl")
-const dtypes = Union{UInt8, Int8, UInt16, Int16, Int32, Float32, Float64}
+const rawtypes = Union{UInt8, N0f8, Int8, UInt16, N0f16, Int16, Int32, Float32, Float64}
+const dtypes = Union{dtypes, SVector{N, <:rawtypes} where N}
 size_t = UInt64
 
 using CxxWrap
@@ -18,25 +21,16 @@ const Scalar = Union{Tuple{}, Tuple{Number}, Tuple{Number, Number}, Tuple{Number
 
 include("Mat.jl")
 
-const InputArray = Union{AbstractArray{T, 3} where {T <: dtypes}, CxxMat}
+const InputArray = Union{AbstractArray{<:dtypes}, CxxMat}
 
 include("mat_conversion.jl")
 include("types_conversion.jl")
 
-function cpp_to_julia(var)
-    return var
-end
-function julia_to_cpp(var)
-    return var
-end
+# Fallbacks
+cpp_to_julia(var) = var
+julia_to_cpp(var) = var
 
-function cpp_to_julia(var::Tuple)
-    ret_arr = Array{Any, 1}()
-    for it in var
-        push!(ret_arr, cpp_to_julia(it))
-    end
-    return tuple(ret_arr...)
-end
+cpp_to_julia(var::Tuple) = map(cpp_to_julia, var)
 
 include("cv_cxx_wrap.jl")
 


### PR DESCRIPTION
This is a proposed redesign that may be a bit more natural to work
with from the Julia perspective. The principal differences are:

- Support eltypes of the form `SVector{T,N}`: this makes this wrapper
  behave more like OpenCV itself, which (unlike Python) does not use
  an array dimension to encode the number of color channels.

- Support `N0f8` and `N0f16`, JuliaImages preferred interpretation of
  8- and 16-bit unsigned intensity data. (See FixedPointNumbers and
  https://juliaimages.org/latest/tutorials/arrays_colors/#fixedpoint;
  interestingly, OpenCV itself suffers from the exact same problem, see
  https://stackoverflow.com/questions/14539498/change-type-of-mat-object-from-cv-32f-to-cv-8u
  for an example of a user who got bit by the "divide by 255" rule.)

- Work towards support for multidimensional arrays (see
  https://github.com/archit120/OpenCV.jl/issues/4)

- Validate arguments more carefully and improve correctness in a few
  key places

- Improve inferrability (https://github.com/archit120/OpenCV.jl/issues/1)

This has not been tested (I don't know how, see https://github.com/archit120/OpenCV.jl/issues/3), so don't merge this unquestioningly.